### PR TITLE
Add `/data` to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Don't include the /data directory, so we can use that to test things out.
+/data
+
 # Don't includes any values-secret.yaml file.
 values-secret.yaml
 


### PR DESCRIPTION
This PR creates a `./data` directory and adds it to `.gitignore`. This would allow us to use the `data` directory for local downloads without worrying that that data will get checked into this repo.