### PR TITLE
Corrected repos for BDC files to go into

### DIFF
--- a/.github/workflows/release-docker-to-renci-containers.yaml
+++ b/.github/workflows/release-docker-to-renci-containers.yaml
@@ -5,7 +5,6 @@ name: "Release Docker package to RENCI Containers"
 
 # Triggered on a release of this code. Uncomment the on:push trigger if you need to test this.
 on:
-  push:
   release:
     types: [published]
 

--- a/.github/workflows/release-docker-to-renci-containers.yaml
+++ b/.github/workflows/release-docker-to-renci-containers.yaml
@@ -5,6 +5,7 @@ name: "Release Docker package to RENCI Containers"
 
 # Triggered on a release of this code. Uncomment the on:push trigger if you need to test this.
 on:
+  push:
   release:
     types: [published]
 

--- a/charts/dug-data-ingest/README.md
+++ b/charts/dug-data-ingest/README.md
@@ -10,3 +10,16 @@ When installing Helm charts from this directory, make sure you include the follo
 - One of the files from `values/` for the specific ingest you want.
 
 You should install multiple CronJobs using this template for each data ingest you want to support.
+
+## Using this Helm chart
+
+This Helm chart creates a [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
+in a Kubernetes cluster set up for either BDC or HEAL ingest. To install this Helm chart, set up Helm and
+then run:
+
+```shell
+$ helm install -n translator-exp -f values/bdc-ingest.yaml -f values-secret.yaml dug-data-ingest-bdc
+```
+
+This will create a CronJob named `dug-data-ingest-bdc` that creates pods named
+`dug-data-ingest-bdc-[alphanumeric code]` on the specified schedule.

--- a/charts/dug-data-ingest/README.md
+++ b/charts/dug-data-ingest/README.md
@@ -18,8 +18,17 @@ in a Kubernetes cluster set up for either BDC or HEAL ingest. To install this He
 then run:
 
 ```shell
-$ helm install -n translator-exp -f values/bdc-ingest.yaml -f values-secret.yaml dug-data-ingest-bdc
+$ helm install -n bdc-dev -f values/bdc-ingest.yaml -f values-secret.yaml dug-data-ingest-bdc
 ```
+
+(If upgrading to a new version of this chart, replace `install` with `upgrade`).
 
 This will create a CronJob named `dug-data-ingest-bdc` that creates pods named
 `dug-data-ingest-bdc-[alphanumeric code]` on the specified schedule.
+
+You can uninstall the Helm chart with:
+
+```shell
+$ helm uninstall -n bdc-dev dug-data-ingest-bdc
+```
+

--- a/charts/dug-data-ingest/README.md
+++ b/charts/dug-data-ingest/README.md
@@ -18,7 +18,7 @@ in a Kubernetes cluster set up for either BDC or HEAL ingest. To install this He
 then run:
 
 ```shell
-$ helm install -n bdc-dev -f values/bdc-ingest.yaml -f values-secret.yaml dug-data-ingest-bdc
+$ helm install -n bdc-dev -f values/bdc-ingest.yaml -f values-secret.yaml dug-data-ingest-bdc .
 ```
 
 (If upgrading to a new version of this chart, replace `install` with `upgrade`).

--- a/charts/dug-data-ingest/values.yaml
+++ b/charts/dug-data-ingest/values.yaml
@@ -20,7 +20,7 @@ lakeFS:
 jobExecutor:
   image:
     repository: containers.renci.org/helxplatform/dug-data-ingest
-    tag: fix-bdc-repos
+    tag: latest
     pullPolicy: Always
   restartPolicy: Never
   backoffLimit: 0

--- a/charts/dug-data-ingest/values.yaml
+++ b/charts/dug-data-ingest/values.yaml
@@ -20,7 +20,7 @@ lakeFS:
 jobExecutor:
   image:
     repository: containers.renci.org/helxplatform/dug-data-ingest
-    tag: add-heal-platform-mds
+    tag: fix-bdc-repos
     pullPolicy: Always
   restartPolicy: Never
   backoffLimit: 0

--- a/scripts/bdc/ingest.sh
+++ b/scripts/bdc/ingest.sh
@@ -54,7 +54,7 @@ sync_dir_to_lakefs() {
   local subdir=$4
 
   # Sync the local directory to the remote directory.
-  rclone sync "$local_dir" "lakefs:$repo_name/$branch_name/$subdir" "$RCLONE_FLAGS"
+  rclone sync "$local_dir" "lakefs:$repo_name/$branch_name/$subdir" $RCLONE_FLAGS
 
   # Commit the sync.
   curl -X POST -u "$LAKEFS_USERNAME:$LAKEFS_PASSWORD" "$LAKEFS_HOST/api/v1/repositories/$repo_name/branches/$branch_name/commits" \

--- a/scripts/bdc/ingest.sh
+++ b/scripts/bdc/ingest.sh
@@ -43,19 +43,19 @@ RCLONE_FLAGS="--progress --track-renames --no-update-modtime"
 # --no-update-modtime: Don't update the last-modified time if the file is identical.
 
 touch /data/bdc/test.txt
-rclone sync "/data/bdc/BioLINCC/" "lakefs:$LAKEFS_REPOSITORY/main/BioLINCC/" $RCLONE_FLAGS
-rclone sync "/data/bdc/COVID19/" "lakefs:$LAKEFS_REPOSITORY/main/COVID19/" $RCLONE_FLAGS
-rclone sync "/data/bdc/DIR/" "lakefs:$LAKEFS_REPOSITORY/main/DIR/" $RCLONE_FLAGS
-rclone sync "/data/bdc/imaging/" "lakefs:$LAKEFS_REPOSITORY/main/imaging/" $RCLONE_FLAGS
-rclone sync "/data/bdc/LungMAP/" "lakefs:$LAKEFS_REPOSITORY/main/LungMAP/" $RCLONE_FLAGS
-rclone sync "/data/bdc/NSRR/" "lakefs:$LAKEFS_REPOSITORY/main/NSRR/" $RCLONE_FLAGS
-rclone sync "/data/bdc/parent/" "lakefs:$LAKEFS_REPOSITORY/main/parent/" $RCLONE_FLAGS
-rclone sync "/data/bdc/PCGC/" "lakefs:$LAKEFS_REPOSITORY/main/PCGC/" $RCLONE_FLAGS
-rclone sync "/data/bdc/RECOVER/" "lakefs:$LAKEFS_REPOSITORY/main/RECOVER/" $RCLONE_FLAGS
-rclone sync "/data/bdc/topmed/" "lakefs:$LAKEFS_REPOSITORY/main/topmed/" $RCLONE_FLAGS
+rclone sync "/data/bdc/BioLINCC/" "lakefs:biolincc/main/" $RCLONE_FLAGS
+rclone sync "/data/bdc/COVID19/" "lakefs:covid19-dbgap/main/" $RCLONE_FLAGS
+rclone sync "/data/bdc/DIR/" "lakefs:dir-dbgap/main/" $RCLONE_FLAGS
+rclone sync "/data/bdc/imaging/" "lakefs:imaging/main/" $RCLONE_FLAGS # TODO: repo not present
+rclone sync "/data/bdc/LungMAP/" "lakefs:lungmap-dbgap/main/" $RCLONE_FLAGS
+rclone sync "/data/bdc/NSRR/" "lakefs:nsrr-dbgap/main/" $RCLONE_FLAGS
+rclone sync "/data/bdc/parent/" "lakefs:parent-dbgap/main/" $RCLONE_FLAGS
+rclone sync "/data/bdc/PCGC/" "lakefs:pcgc-dbgap/main/" $RCLONE_FLAGS
+rclone sync "/data/bdc/RECOVER/" "lakefs:recover-dbgap/main/" $RCLONE_FLAGS
+rclone sync "/data/bdc/topmed/" "lakefs:topmed-gen3-dbgap/main/" $RCLONE_FLAGS
 
 # Save logs into repository as well.
-rclone sync "/data/logs" "lakefs:$LAKEFS_REPOSITORY/main/logs/" $RCLONE_FLAGS
+rclone sync "/data/logs" "lakefs:bdc-gen3-import/main/logs/" $RCLONE_FLAGS # TODO: repo not present
 
 # Step 4. Commit these changes. We could do this via lakefs CLI, but it's easier to just do it via curl.
 curl -X POST -u "$LAKEFS_USERNAME:$LAKEFS_PASSWORD" "$LAKEFS_HOST/api/v1/repositories/$LAKEFS_REPOSITORY/branches/main/commits" \


### PR DESCRIPTION
During development, we assumed that all BDC files should go into a single repo, but in practice we want to spread them among a number of different repos. This PR starts the process of choosing where those files should go.
- [x] Imaging repo: imaging
- [x] Logs: bdc-roger into a subdirectory (rclone copy instead of rclone sync maybe for safety?)
- [x] Branch: for now, continue committing to main, but we might add an extra step in the workflow to tag things in the future.
- [x] Add command line to the README

This has uploaded data into all the appropriate LakeFS repositories except PCGC, because:
- Even though phs001735.v2.p1 has the word PCGC in its filenames (e.g. `phs001735.v2.pht009982.v2.TOPMed_WGS_PCGC_Sample_Attributes.data_dict.xml`), BDC Gen3 tells us that it's in the `topmed` program.
- Study phs001843.v1.p2 is marked as a PCGC study by BDC Gen3, but this study is completely unknown to DBGaP (see https://ftp.ncbi.nlm.nih.gov/dbgap/studies/phs001843/).