### PR TITLE
Fix bugs in HEAL ingest

### DIFF
--- a/.github/workflows/release-docker-to-renci-containers.yaml
+++ b/.github/workflows/release-docker-to-renci-containers.yaml
@@ -5,7 +5,6 @@ name: "Release Docker package to RENCI Containers"
 
 # Triggered on a release of this code. Uncomment the on:push trigger if you need to test this.
 on:
-  push:
   release:
     types: [published]
 

--- a/.github/workflows/release-docker-to-renci-containers.yaml
+++ b/.github/workflows/release-docker-to-renci-containers.yaml
@@ -5,6 +5,7 @@ name: "Release Docker package to RENCI Containers"
 
 # Triggered on a release of this code. Uncomment the on:push trigger if you need to test this.
 on:
+  push:
   release:
     types: [published]
 

--- a/charts/dug-data-ingest/values/heal-ingest.yaml
+++ b/charts/dug-data-ingest/values/heal-ingest.yaml
@@ -6,4 +6,4 @@ jobExecutor:
   script: heal/ingest.sh
   lakeFSRepository: heal-mds-import
   image:
-    tag: fix-additional-heal-bugs
+    tag: latest

--- a/charts/dug-data-ingest/values/heal-ingest.yaml
+++ b/charts/dug-data-ingest/values/heal-ingest.yaml
@@ -6,4 +6,4 @@ jobExecutor:
   script: heal/ingest.sh
   lakeFSRepository: heal-mds-import
   image:
-    tag: latest
+    tag: fix-additional-heal-bugs

--- a/charts/dug-data-ingest/values/heal-ingest.yaml
+++ b/charts/dug-data-ingest/values/heal-ingest.yaml
@@ -5,3 +5,5 @@ dataStorage: 200Mi
 jobExecutor:
   script: heal/ingest.sh
   lakeFSRepository: heal-mds-import
+  image:
+    tag: fix-heal-bugs

--- a/charts/dug-data-ingest/values/heal-ingest.yaml
+++ b/charts/dug-data-ingest/values/heal-ingest.yaml
@@ -6,4 +6,4 @@ jobExecutor:
   script: heal/ingest.sh
   lakeFSRepository: heal-mds-import
   image:
-    tag: fix-heal-bugs
+    tag: latest

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -257,7 +257,7 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
     dbgap_files_generated = set()
 
     # Create a complete variable index for every variable we find.
-    variable_index = []
+    all_variable_index = []
 
     data_dict_files = os.listdir(studies_with_data_dicts_dir)
     for data_dict_file in data_dict_files:
@@ -443,7 +443,7 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
 
                     variable_entry['encodings'] = "||".join(map(lambda x: f"{x[0]}={x[1]}", encs.items()))
 
-                variable_index.append(variable_entry)
+                all_variable_index.append(variable_entry)
 
             logging.info(f"Added {variable_count} variables in data dictionary {data_dict['@id']} in {file_path} for study {study_name}.")
 
@@ -466,10 +466,10 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
         header = ['study_id', 'dd_id', 'name', 'module', 'title', 'description', 'type', 'encodings']
 
         csv_writer = csv.DictWriter(f, fieldnames=header)
-        for row in variable_index:
+        for row in all_variable_index:
             csv_writer.writerow(row)
 
-    logging.info(f"Wrote variable index of {len(variable_index)} variables to {variable_index_filename}.")
+    logging.info(f"Wrote variable index of {len(all_variable_index)} variables to {variable_index_filename}.")
 
     return dbgap_files_generated
 

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -413,8 +413,6 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                         variable_entry['logical_max'] = str(var_dict['constraints']['maximum'])
 
                     # Determine a type for this variable.
-                    enum_values = []
-                    enum_labels = {}
                     typ = var_dict.get('type')
                     if 'enum' in var_dict['constraints'] and len(var_dict['constraints']['enum']) > 0:
                         typ = 'encoded value'

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -466,6 +466,7 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
         header = ['study_id', 'dd_id', 'name', 'module', 'title', 'description', 'type', 'encodings', 'logical_min', 'logical_max']
 
         csv_writer = csv.DictWriter(f, fieldnames=header)
+        csv_writer.writeheader()
         for row in all_variable_index:
             csv_writer.writerow(row)
 

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -424,7 +424,10 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                         for key in enum_values:
                             value_element = ET.SubElement(variable, 'value')
                             value_element.set('code', key)
-                            value_element.text = enum_labels.get(key, '')
+                            try:
+                                value_element.text = enum_labels[key]
+                            except KeyError as e:
+                                logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}: {e}")
 
                     if typ:
                         type_element = ET.SubElement(variable, 'type')

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -422,6 +422,12 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                         enum_labels = var_dict.get('enumLabels', {})
                         encodings = []
 
+                        # In some older data dictionaries, the enumLabels are stored in the `encodings` string.
+                        if 'encodings' in var_dict_constraints and len(enum_labels) == 0:
+                            for pair in var_dict_constraints['encodings'].split('|'):
+                                key, value = pair.split('=')
+                                enum_labels[key.strip()] = value.strip()
+
                         for key in enum_values:
                             value_element = ET.SubElement(variable, 'value')
                             value_element.set('code', key)

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -9,7 +9,6 @@
 import csv
 import json
 import os
-import re
 import click
 import logging
 import requests
@@ -38,6 +37,7 @@ def translate_data_dictionary_field(field):
 
     result = field.copy()
 
+    # The variable name could be called 'name' or 'property' (for older data dictionaries).
     if 'name' in field:
         result['name'] = field['name']
     elif 'property' in field:
@@ -45,8 +45,11 @@ def translate_data_dictionary_field(field):
     else:
         raise ValueError(f"Unable to translate field {field}: missing name or property")
 
+    # The section name could be called 'section', 'module' or 'node'.
     if 'section' in field:
         result['section'] = field['section']
+    elif 'module' in field:
+        result['section'] = field['module']
     elif 'node' in field:
         result['section'] = field['node']
 
@@ -63,6 +66,7 @@ def download_from_mds(studies_dir, data_dicts_dir, studies_with_data_dicts_dir, 
     :param data_dicts_dir: The directory into which to write the data dictionaries.
     :param studies_with_data_dicts_dir: The directory into which to write the studies with data dictionaries.
     :param mds_metadata_endpoint: The Platform MDS endpoint to use.
+    :param mds_limit: The maximum number of studies to download from the MDS. TODO: add support for queries beyond the limit.
     :return: A dictionary of all the studies, with the study ID as keys.
     """
 
@@ -500,6 +504,8 @@ def get_heal_platform_mds_data_dicts(output, mds_metadata_endpoint, limit):
     build code that could be quickly rewritten for other MDS schemas.
 
     :param output: The output directory, which should not exist when the script is run.
+    :param mds_metadata_endpoint: The MDS metadata endpoint to use, e.g. https://healdata.org/mds/metadata
+    :param limit: The maximum number of entries to retrieve from the Platform MDS. Note that some MDS instances have their own built-in limit; if you hit that limit, you will need to update the code to support offsets.
     """
 
     # Don't allow the program to run if the output directory already exists.

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -36,7 +36,7 @@ def translate_data_dictionary_field(field):
     :raise ValueError: if we can't figure out the information in the input field.
     """
 
-    result = {}
+    result = field.copy()
 
     if 'name' in field:
         result['name'] = field['name']
@@ -44,12 +44,6 @@ def translate_data_dictionary_field(field):
         result['name'] = field['property']
     else:
         raise ValueError(f"Unable to translate field {field}: missing name or property")
-
-    if 'title' in field:
-        result['title'] = field['title']
-
-    if 'description' in field:
-        result['description']  = field['description']
 
     if 'section' in field:
         result['section'] = field['section']
@@ -401,6 +395,7 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                     variable_entry['section'] = var_dict['section']
 
                 # Add constraints.
+                logging.debug(f"Looking for constraints in {data_dict['@id']} for {data_table.get('study_id')}: {json.dumps(var_dict, indent=2, sort_keys=True)}")
                 if 'constraints' in var_dict:
                     var_dict_constraints = var_dict['constraints']
                     

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -413,35 +413,23 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                         variable_entry['logical_max'] = str(var_dict['constraints']['maximum'])
 
                     # Determine a type for this variable.
+                    enum_values = []
+                    enum_labels = {}
                     typ = var_dict.get('type')
                     if 'enum' in var_dict['constraints'] and len(var_dict['constraints']['enum']) > 0:
                         typ = 'encoded value'
+                        enum_values = var_dict['constraints']['enum']
+                        enum_labels = var_dict.get('enumLabels', {})
+
+                        for key in enum_values:
+                            value_element = ET.SubElement(variable, 'value')
+                            value_element.set('code', key)
+                            value_element.text = enum_labels.get(key, '')
+
                     if typ:
                         type_element = ET.SubElement(variable, 'type')
                         type_element.text = typ
                         variable_entry['type'] = typ
-
-                # If there are encodings, we need to convert them into values.
-                if 'encodings' in var_dict:
-                    encs = {}
-                    for encoding in re.split("\\s*\\|\\s*", var_dict['encodings']):
-                        m = re.fullmatch("^\\s*(.*?)\\s*=\\s*(.*)\\s*$", encoding)
-                        if not m:
-                            raise RuntimeError(
-                                f"Could not parse encodings {var_dict['encodings']} in data dictionary file {file_path}")
-                        key = m.group(1)
-                        value = m.group(2)
-                        if key in encs:
-                            raise RuntimeError(
-                                f"Duplicate key detected in encodings {var_dict['encodings']} in data dictionary file {file_path}")
-                        encs[key] = value
-
-                    for key, value in encs.items():
-                        value_element = ET.SubElement(variable, 'value')
-                        value_element.set('code', key)
-                        value_element.text = value
-
-                    variable_entry['encodings'] = "||".join(map(lambda x: f"{x[0]}={x[1]}", encs.items()))
 
                 all_variable_index.append(variable_entry)
 

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -420,16 +420,23 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                         typ = 'encoded value'
                         enum_values = var_dict_constraints['enum']
                         enum_labels = var_dict.get('enumLabels', {})
+                        encodings = []
 
                         for key in enum_values:
                             value_element = ET.SubElement(variable, 'value')
                             value_element.set('code', key)
                             try:
-                                value_element.text = enum_labels[key]
-                            except KeyError as e:
+                                value = enum_labels[key]
+                                encodings.append(f"{key}={enum_labels[key]}")
+                            except KeyError:
                                 logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}, using {key} as value.")
-                                value_element.text = key
-                                
+                                value = key
+
+                            value_element.text = value
+                            encodings.append(f"{key}={value}")
+
+                        variable_entry['encodings'] = "|".join(encodings)
+
                     if typ:
                         type_element = ET.SubElement(variable, 'type')
                         type_element.text = typ

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -20,6 +20,7 @@ import xml.dom.minidom as minidom
 DEFAULT_MDS_ENDPOINT = 'https://healdata.org/mds/metadata'
 MDS_DEFAULT_LIMIT = 10000
 DATA_DICT_GUID_TYPE = 'data_dictionary'
+HEAL_STUDY_GUID_TYPE = 'discovery_metadata'
 HDP_ID_PREFIX = 'HEALDATAPLATFORM:'
 
 # Turn on logging
@@ -88,6 +89,7 @@ def download_from_mds(studies_dir, data_dicts_dir, studies_with_data_dicts_dir, 
     #
     # TODO: extend this so it can function even if there are more than mds_limit data dictionaries.
     result = requests.get(mds_metadata_endpoint, params={
+        '_guid_type': HEAL_STUDY_GUID_TYPE,
         'limit': mds_limit,
     })
     if not result.ok:

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -427,9 +427,8 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                             value_element.set('code', key)
                             try:
                                 value = enum_labels[key]
-                                encodings.append(f"{key}={enum_labels[key]}")
                             except KeyError:
-                                logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}, using {key} as value.")
+                                logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}, using '{key}' as value.")
                                 value = key
 
                             value_element.text = value

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -52,9 +52,9 @@ def translate_data_dictionary_field(field):
         result['description']  = field['description']
 
     if 'section' in field:
-        result['module'] = field['section']
+        result['section'] = field['section']
     elif 'node' in field:
-        result['module'] = field['node']
+        result['section'] = field['node']
 
     return result
 
@@ -396,9 +396,9 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                 # Export the `module` field so that we can look for instruments.
                 # TODO: this is a custom field. Instead of this, we could export each data dictionary as a separate dbGaP
                 # file. Need to check to see what works better for Dug ingest.
-                if 'module' in var_dict:
-                    variable.set('module', var_dict['module'])
-                    variable_entry['module'] = var_dict['module']
+                if 'section' in var_dict:
+                    variable.set('section', var_dict['section'])
+                    variable_entry['section'] = var_dict['section']
 
                 # Add constraints.
                 if 'constraints' in var_dict:
@@ -463,7 +463,7 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
     # Write a full variable index to the output XML filename directory.
     variable_index_filename = os.path.join(dbgap_dir, 'variable_index.csv')
     with open(variable_index_filename, 'w') as f:
-        header = ['study_id', 'dd_id', 'name', 'module', 'title', 'description', 'type', 'encodings', 'logical_min', 'logical_max']
+        header = ['study_id', 'dd_id', 'name', 'section', 'title', 'description', 'type', 'encodings', 'logical_min', 'logical_max']
 
         csv_writer = csv.DictWriter(f, fieldnames=header)
         csv_writer.writeheader()

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -463,7 +463,7 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
     # Write a full variable index to the output XML filename directory.
     variable_index_filename = os.path.join(dbgap_dir, 'variable_index.csv')
     with open(variable_index_filename, 'w') as f:
-        header = ['study_id', 'dd_id', 'name', 'module', 'title', 'description', 'type', 'encodings']
+        header = ['study_id', 'dd_id', 'name', 'module', 'title', 'description', 'type', 'encodings', 'logical_min', 'logical_max']
 
         csv_writer = csv.DictWriter(f, fieldnames=header)
         for row in all_variable_index:

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -427,8 +427,9 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                             try:
                                 value_element.text = enum_labels[key]
                             except KeyError as e:
-                                logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}: {e}")
-
+                                logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}, using {key} as value.")
+                                value_element.text = key
+                                
                     if typ:
                         type_element = ET.SubElement(variable, 'type')
                         type_element.text = typ

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -402,21 +402,23 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
 
                 # Add constraints.
                 if 'constraints' in var_dict:
+                    var_dict_constraints = var_dict['constraints']
+                    
                     # Check for minimum and maximum constraints.
-                    if 'minimum' in var_dict['constraints']:
+                    if 'minimum' in var_dict_constraints:
                         logical_min = ET.SubElement(variable, 'logical_min')
-                        logical_min.text = str(var_dict['constraints']['minimum'])
-                        variable_entry['logical_min'] = str(var_dict['constraints']['minimum'])
-                    if 'maximum' in var_dict['constraints']:
+                        logical_min.text = str(var_dict_constraints['minimum'])
+                        variable_entry['logical_min'] = str(var_dict_constraints['minimum'])
+                    if 'maximum' in var_dict_constraints:
                         logical_max = ET.SubElement(variable, 'logical_max')
-                        logical_max.text = str(var_dict['constraints']['maximum'])
-                        variable_entry['logical_max'] = str(var_dict['constraints']['maximum'])
+                        logical_max.text = str(var_dict_constraints['maximum'])
+                        variable_entry['logical_max'] = str(var_dict_constraints['maximum'])
 
                     # Determine a type for this variable.
                     typ = var_dict.get('type')
-                    if 'enum' in var_dict['constraints'] and len(var_dict['constraints']['enum']) > 0:
+                    if 'enum' in var_dict_constraints and len(var_dict_constraints['enum']) > 0:
                         typ = 'encoded value'
-                        enum_values = var_dict['constraints']['enum']
+                        enum_values = var_dict_constraints['enum']
                         enum_labels = var_dict.get('enumLabels', {})
 
                         for key in enum_values:

--- a/scripts/heal/ingest.sh
+++ b/scripts/heal/ingest.sh
@@ -8,13 +8,13 @@ START_DATE=$(date)
 echo Started ingest from HEAL Platform at ${START_DATE}.
 
 # Step 1. Prepare directories.
-echo Cleaning /data directory
-rm -rf /data/*
+echo Cleaning data directory
+rm -rf data/*
 
-mkdir -p /data/logs
+mkdir -p data/logs
 
 # Step 2. Download the list of dbGaP IDs from BDC.
-python heal/get_heal_platform_mds_data_dicts.py /data/heal 2>&1 | tee /data/logs/get_heal_platform_mds_data_dicts.log
+python get_heal_platform_mds_data_dicts.py data/heal 2>&1 | tee data/logs/get_heal_platform_mds_data_dicts.log
 
 # Step 3. Upload the files to BDC.
 echo Uploading dbGaP XML files to LakeFS using Rclone.
@@ -32,10 +32,10 @@ RCLONE_FLAGS="--progress --track-renames --no-update-modtime"
 # Sync (https://rclone.org/commands/rclone_sync/)
 # --track-renames: If a file exists but has only been renamed, record that on the destination.
 # --no-update-modtime: Don't update the last-modified time if the file is identical.
-rclone sync "/data/heal/dbGaPs/" "lakefs:$LAKEFS_REPOSITORY/main/" $RCLONE_FLAGS
+rclone sync "data/heal/dbGaPs/" "lakefs:$LAKEFS_REPOSITORY/main/" $RCLONE_FLAGS
 
 # Step 4. Upload logs with RClone.
-rclone sync "/data/logs/" "lakefs:$LAKEFS_REPOSITORY/main/logs/" $RCLONE_FLAGS
+rclone sync "data/logs/" "lakefs:$LAKEFS_REPOSITORY/main/logs/" $RCLONE_FLAGS
 
 # Step 5. Commit these changes. We could do this via lakefs CLI, but it's easier to just do it via curl.
 curl -X POST -u "$LAKEFS_USERNAME:$LAKEFS_PASSWORD" "$LAKEFS_HOST/api/v1/repositories/$LAKEFS_REPOSITORY/branches/main/commits" \

--- a/scripts/heal/ingest.sh
+++ b/scripts/heal/ingest.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 
 # CONFIGURATION
 # The data directory that we download data to.
-DATA_DIR=/data
-SCRIPT_DIR=heal
+DATA_DIR=${HEAL_INGEST_DATA_DIR:-/data}
+SCRIPT_DIR=${HEAL_INGEST_SCRIPT_DIR:-heal}
 
 # A script for ingesting data from HEAL Platform dbGaP XML files into LakeFS.
 START_DATE=$(date)
-echo Started ingest from HEAL Platform at ${START_DATE}.
+echo Started ingest from HEAL Platform to ${DATA_DIR} at ${START_DATE}.
 
 # Step 1. Prepare directories.
 echo Cleaning data directory

--- a/scripts/heal/ingest.sh
+++ b/scripts/heal/ingest.sh
@@ -21,6 +21,10 @@ mkdir -p $DATA_DIR/logs
 # Step 2. Download the list of dbGaP IDs from BDC.
 python $SCRIPT_DIR/get_heal_platform_mds_data_dicts.py $DATA_DIR/heal 2>&1 | tee $DATA_DIR/logs/get_heal_platform_mds_data_dicts.log
 
+# Step 2.1. Copy the errors and warnings into a separate file.
+grep -i "ERROR" $DATA_DIR/logs/get_heal_platform_mds_data_dicts.log > $DATA_DIR/logs/errors.log
+grep -i "WARNING" $DATA_DIR/logs/get_heal_platform_mds_data_dicts.log > $DATA_DIR/logs/warnings.log
+
 # Step 3. Upload the files to BDC.
 echo Uploading dbGaP XML files to LakeFS using Rclone.
 

--- a/scripts/heal/ingest.sh
+++ b/scripts/heal/ingest.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # CONFIGURATION
 # The data directory that we download data to.
 DATA_DIR=/data
+SCRIPT_DIR=heal
 
 # A script for ingesting data from HEAL Platform dbGaP XML files into LakeFS.
 START_DATE=$(date)
@@ -18,7 +19,7 @@ rm -rf $DATA_DIR/*
 mkdir -p $DATA_DIR/logs
 
 # Step 2. Download the list of dbGaP IDs from BDC.
-python get_heal_platform_mds_data_dicts.py $DATA_DIR/heal 2>&1 | tee $DATA_DIR/logs/get_heal_platform_mds_data_dicts.log
+python $SCRIPT_DIR/get_heal_platform_mds_data_dicts.py $DATA_DIR/heal 2>&1 | tee $DATA_DIR/logs/get_heal_platform_mds_data_dicts.log
 
 # Step 3. Upload the files to BDC.
 echo Uploading dbGaP XML files to LakeFS using Rclone.


### PR DESCRIPTION
The VLMD format used by the Platform MDS changed at some point, causing the HEAL ingest script to stop working. This PR updates the code so it works again. It also adds an all-variable index file, which includes all the variables included in this repository. Other fixes include:
- Improved scripts/heal/ingest.sh so that it can be overridden with environmental variables.
- Filter studies to a type of `discovery_metadata`, which would avoid pulling in `discovery_metadata_archive` studies which have been archived and are not accessible from the HEAL Data Platform.
- Fixed the enumerated value ingest, which was based on the CSV format, not the JSON format used by the Platform MDS (closes #21).

Other minor changes:
- Added an explicit `latest` tag for the Kubernetes image so it's easier to change it later for testing.
- Added a `DATA_DIR` configuration variable to the HEAL ingest script so that it's easier to test it locally.
- Separate errors.log and warnings.log files are now generated with just the errors and warnings so they are easier to spot.