### PR TITLE
Fix some additional bugs in the HEAL Data Ingest

### DIFF
--- a/.github/workflows/release-docker-to-renci-containers.yaml
+++ b/.github/workflows/release-docker-to-renci-containers.yaml
@@ -5,6 +5,7 @@ name: "Release Docker package to RENCI Containers"
 
 # Triggered on a release of this code. Uncomment the on:push trigger if you need to test this.
 on:
+  push:
   release:
     types: [published]
 

--- a/charts/dug-data-ingest/values/heal-ingest.yaml
+++ b/charts/dug-data-ingest/values/heal-ingest.yaml
@@ -6,4 +6,4 @@ jobExecutor:
   script: heal/ingest.sh
   lakeFSRepository: heal-mds-import
   image:
-    tag: latest
+    tag: fix-additional-heal-bugs

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -413,8 +413,6 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                         variable_entry['logical_max'] = str(var_dict['constraints']['maximum'])
 
                     # Determine a type for this variable.
-                    enum_values = []
-                    enum_labels = {}
                     typ = var_dict.get('type')
                     if 'enum' in var_dict['constraints'] and len(var_dict['constraints']['enum']) > 0:
                         typ = 'encoded value'

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -424,7 +424,10 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                         for key in enum_values:
                             value_element = ET.SubElement(variable, 'value')
                             value_element.set('code', key)
-                            value_element.text = enum_labels.get(key, '')
+                            try:
+                                value_element.text = enum_labels[key]
+                            except KeyError as e:
+                                logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}: {e}")
 
                     if typ:
                         type_element = ET.SubElement(variable, 'type')

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -422,6 +422,12 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                         enum_labels = var_dict.get('enumLabels', {})
                         encodings = []
 
+                        # In some older data dictionaries, the enumLabels are stored in the `encodings` string.
+                        if 'encodings' in var_dict_constraints and len(enum_labels) == 0:
+                            for pair in var_dict_constraints['encodings'].split('|'):
+                                key, value = pair.split('=')
+                                enum_labels[key.strip()] = value.strip()
+
                         for key in enum_values:
                             value_element = ET.SubElement(variable, 'value')
                             value_element.set('code', key)

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -9,7 +9,6 @@
 import csv
 import json
 import os
-import re
 import click
 import logging
 import requests
@@ -38,6 +37,7 @@ def translate_data_dictionary_field(field):
 
     result = field.copy()
 
+    # The variable name could be called 'name' or 'property' (for older data dictionaries).
     if 'name' in field:
         result['name'] = field['name']
     elif 'property' in field:
@@ -45,8 +45,11 @@ def translate_data_dictionary_field(field):
     else:
         raise ValueError(f"Unable to translate field {field}: missing name or property")
 
+    # The section name could be called 'section', 'module' or 'node'.
     if 'section' in field:
         result['section'] = field['section']
+    elif 'module' in field:
+        result['section'] = field['module']
     elif 'node' in field:
         result['section'] = field['node']
 
@@ -63,6 +66,7 @@ def download_from_mds(studies_dir, data_dicts_dir, studies_with_data_dicts_dir, 
     :param data_dicts_dir: The directory into which to write the data dictionaries.
     :param studies_with_data_dicts_dir: The directory into which to write the studies with data dictionaries.
     :param mds_metadata_endpoint: The Platform MDS endpoint to use.
+    :param mds_limit: The maximum number of studies to download from the MDS. TODO: add support for queries beyond the limit.
     :return: A dictionary of all the studies, with the study ID as keys.
     """
 
@@ -500,6 +504,8 @@ def get_heal_platform_mds_data_dicts(output, mds_metadata_endpoint, limit):
     build code that could be quickly rewritten for other MDS schemas.
 
     :param output: The output directory, which should not exist when the script is run.
+    :param mds_metadata_endpoint: The MDS metadata endpoint to use, e.g. https://healdata.org/mds/metadata
+    :param limit: The maximum number of entries to retrieve from the Platform MDS. Note that some MDS instances have their own built-in limit; if you hit that limit, you will need to update the code to support offsets.
     """
 
     # Don't allow the program to run if the output directory already exists.

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -36,7 +36,7 @@ def translate_data_dictionary_field(field):
     :raise ValueError: if we can't figure out the information in the input field.
     """
 
-    result = {}
+    result = field.copy()
 
     if 'name' in field:
         result['name'] = field['name']
@@ -44,12 +44,6 @@ def translate_data_dictionary_field(field):
         result['name'] = field['property']
     else:
         raise ValueError(f"Unable to translate field {field}: missing name or property")
-
-    if 'title' in field:
-        result['title'] = field['title']
-
-    if 'description' in field:
-        result['description']  = field['description']
 
     if 'section' in field:
         result['section'] = field['section']
@@ -401,6 +395,7 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                     variable_entry['section'] = var_dict['section']
 
                 # Add constraints.
+                logging.debug(f"Looking for constraints in {data_dict['@id']} for {data_table.get('study_id')}: {json.dumps(var_dict, indent=2, sort_keys=True)}")
                 if 'constraints' in var_dict:
                     var_dict_constraints = var_dict['constraints']
                     

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -413,35 +413,23 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                         variable_entry['logical_max'] = str(var_dict['constraints']['maximum'])
 
                     # Determine a type for this variable.
+                    enum_values = []
+                    enum_labels = {}
                     typ = var_dict.get('type')
                     if 'enum' in var_dict['constraints'] and len(var_dict['constraints']['enum']) > 0:
                         typ = 'encoded value'
+                        enum_values = var_dict['constraints']['enum']
+                        enum_labels = var_dict.get('enumLabels', {})
+
+                        for key in enum_values:
+                            value_element = ET.SubElement(variable, 'value')
+                            value_element.set('code', key)
+                            value_element.text = enum_labels.get(key, '')
+
                     if typ:
                         type_element = ET.SubElement(variable, 'type')
                         type_element.text = typ
                         variable_entry['type'] = typ
-
-                # If there are encodings, we need to convert them into values.
-                if 'encodings' in var_dict:
-                    encs = {}
-                    for encoding in re.split("\\s*\\|\\s*", var_dict['encodings']):
-                        m = re.fullmatch("^\\s*(.*?)\\s*=\\s*(.*)\\s*$", encoding)
-                        if not m:
-                            raise RuntimeError(
-                                f"Could not parse encodings {var_dict['encodings']} in data dictionary file {file_path}")
-                        key = m.group(1)
-                        value = m.group(2)
-                        if key in encs:
-                            raise RuntimeError(
-                                f"Duplicate key detected in encodings {var_dict['encodings']} in data dictionary file {file_path}")
-                        encs[key] = value
-
-                    for key, value in encs.items():
-                        value_element = ET.SubElement(variable, 'value')
-                        value_element.set('code', key)
-                        value_element.text = value
-
-                    variable_entry['encodings'] = "||".join(map(lambda x: f"{x[0]}={x[1]}", encs.items()))
 
                 all_variable_index.append(variable_entry)
 

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -420,16 +420,23 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                         typ = 'encoded value'
                         enum_values = var_dict_constraints['enum']
                         enum_labels = var_dict.get('enumLabels', {})
+                        encodings = []
 
                         for key in enum_values:
                             value_element = ET.SubElement(variable, 'value')
                             value_element.set('code', key)
                             try:
-                                value_element.text = enum_labels[key]
-                            except KeyError as e:
+                                value = enum_labels[key]
+                                encodings.append(f"{key}={enum_labels[key]}")
+                            except KeyError:
                                 logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}, using {key} as value.")
-                                value_element.text = key
-                                
+                                value = key
+
+                            value_element.text = value
+                            encodings.append(f"{key}={value}")
+
+                        variable_entry['encodings'] = "|".join(encodings)
+
                     if typ:
                         type_element = ET.SubElement(variable, 'type')
                         type_element.text = typ

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -20,6 +20,7 @@ import xml.dom.minidom as minidom
 DEFAULT_MDS_ENDPOINT = 'https://healdata.org/mds/metadata'
 MDS_DEFAULT_LIMIT = 10000
 DATA_DICT_GUID_TYPE = 'data_dictionary'
+HEAL_STUDY_GUID_TYPE = 'discovery_metadata'
 HDP_ID_PREFIX = 'HEALDATAPLATFORM:'
 
 # Turn on logging
@@ -88,6 +89,7 @@ def download_from_mds(studies_dir, data_dicts_dir, studies_with_data_dicts_dir, 
     #
     # TODO: extend this so it can function even if there are more than mds_limit data dictionaries.
     result = requests.get(mds_metadata_endpoint, params={
+        '_guid_type': HEAL_STUDY_GUID_TYPE,
         'limit': mds_limit,
     })
     if not result.ok:

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -427,9 +427,8 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                             value_element.set('code', key)
                             try:
                                 value = enum_labels[key]
-                                encodings.append(f"{key}={enum_labels[key]}")
                             except KeyError:
-                                logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}, using {key} as value.")
+                                logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}, using '{key}' as value.")
                                 value = key
 
                             value_element.text = value

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -427,8 +427,9 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
                             try:
                                 value_element.text = enum_labels[key]
                             except KeyError as e:
-                                logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}: {e}")
-
+                                logging.warning(f"No enumLabel found for code '{key}' in enumLabels {enum_labels}, using {key} as value.")
+                                value_element.text = key
+                                
                     if typ:
                         type_element = ET.SubElement(variable, 'type')
                         type_element.text = typ

--- a/scripts/heal/get_heal_platform_mds_data_dicts.py
+++ b/scripts/heal/get_heal_platform_mds_data_dicts.py
@@ -402,21 +402,23 @@ def generate_dbgap_files(dbgap_dir, studies_with_data_dicts_dir):
 
                 # Add constraints.
                 if 'constraints' in var_dict:
+                    var_dict_constraints = var_dict['constraints']
+                    
                     # Check for minimum and maximum constraints.
-                    if 'minimum' in var_dict['constraints']:
+                    if 'minimum' in var_dict_constraints:
                         logical_min = ET.SubElement(variable, 'logical_min')
-                        logical_min.text = str(var_dict['constraints']['minimum'])
-                        variable_entry['logical_min'] = str(var_dict['constraints']['minimum'])
-                    if 'maximum' in var_dict['constraints']:
+                        logical_min.text = str(var_dict_constraints['minimum'])
+                        variable_entry['logical_min'] = str(var_dict_constraints['minimum'])
+                    if 'maximum' in var_dict_constraints:
                         logical_max = ET.SubElement(variable, 'logical_max')
-                        logical_max.text = str(var_dict['constraints']['maximum'])
-                        variable_entry['logical_max'] = str(var_dict['constraints']['maximum'])
+                        logical_max.text = str(var_dict_constraints['maximum'])
+                        variable_entry['logical_max'] = str(var_dict_constraints['maximum'])
 
                     # Determine a type for this variable.
                     typ = var_dict.get('type')
-                    if 'enum' in var_dict['constraints'] and len(var_dict['constraints']['enum']) > 0:
+                    if 'enum' in var_dict_constraints and len(var_dict_constraints['enum']) > 0:
                         typ = 'encoded value'
-                        enum_values = var_dict['constraints']['enum']
+                        enum_values = var_dict_constraints['enum']
                         enum_labels = var_dict.get('enumLabels', {})
 
                         for key in enum_values:

--- a/scripts/heal/ingest.sh
+++ b/scripts/heal/ingest.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 
 # CONFIGURATION
 # The data directory that we download data to.
-DATA_DIR=/data
-SCRIPT_DIR=heal
+DATA_DIR=${HEAL_INGEST_DATA_DIR:-/data}
+SCRIPT_DIR=${HEAL_INGEST_SCRIPT_DIR:-heal}
 
 # A script for ingesting data from HEAL Platform dbGaP XML files into LakeFS.
 START_DATE=$(date)
-echo Started ingest from HEAL Platform at ${START_DATE}.
+echo Started ingest from HEAL Platform to ${DATA_DIR} at ${START_DATE}.
 
 # Step 1. Prepare directories.
 echo Cleaning data directory


### PR DESCRIPTION
Changes include:
- Improved scripts/heal/ingest.sh so that it can be overridden with environmental variables.
- Filter studies to a type of `discovery_metadata`, which would avoid pulling in `discovery_metadata_archive` studies which have been archived and are not accessible from the HEAL Data Platform.
- Fixed the enumerated value ingest, which was based on the CSV format, not the JSON format used by the Platform MDS (closes #21).

WIP. Should be merged after PR #13.