### PR TITLE
Updated LakeFS to internal URL

### DIFF
--- a/charts/dug-data-ingest/values.yaml
+++ b/charts/dug-data-ingest/values.yaml
@@ -12,7 +12,7 @@ dataStorage: 200Mi
 
 # LakeFS information.
 lakeFS:
-  host: https://lakefs.apps.renci.org
+  host: http://lakefs.lakefs
   username: TODO # see in values-secret.yaml
   password: TODO # see in values-secret.yaml
 


### PR DESCRIPTION
We've been running into HTTP 413 Content Too Large errors, but bypassing the Kubernetes ingress by using its internal URL fixes this issue.